### PR TITLE
Fix the typo

### DIFF
--- a/Templates/PreviewTests.stencil
+++ b/Templates/PreviewTests.stencil
@@ -131,7 +131,7 @@ import SnapshotTesting
                     traits: prefireSnapshot.traits
                 )
             ),
-            record: preferences.record,{% if argument.file %}
+            record: preferences.record{% if argument.file %},
             file: file{% endif %},
             testName: prefireSnapshot.name
         )


### PR DESCRIPTION
### Short description 📝
> After adding '.prefire.yml' configuration file, build fails saying: "Unexpected ',' separator". 

`record: preferences.record,,`

### Solution 📦
Move a comma after expression:

Before:
`record: preferences.record,{% if argument.file %}`

After:
`record: preferences.record{% if argument.file %},`

### Implementation 👩‍💻👨‍💻
Just move the comma.
